### PR TITLE
Add support for CSS classes to editor component 

### DIFF
--- a/BlazorEditorJs.App/BlazorEditorJs.App.Client/Pages/Home.razor
+++ b/BlazorEditorJs.App/BlazorEditorJs.App.Client/Pages/Home.razor
@@ -12,4 +12,4 @@
     <button type="button" class="btn btn-outline-primary" @onclick="CheckEditorValueAsync">Check Value (Console)</button>
 </div>
 
-<Editor @ref="editor_02" Id="editorjs-blazor-02" Name="editorjs-blazor-02" Value="EditorValue02" ValueChanged="OnEditorValue02Changed" Tools="EditorTools02" Configurations="EditorConfigurations02" Style="margin-top: 20px; border: thin dashed grey; padding: 0 20px 0 20px;" />
+<Editor @ref="editor_02" Id="editorjs-blazor-02" Name="editorjs-blazor-02" Value="EditorValue02" ValueChanged="OnEditorValue02Changed" Tools="EditorTools02" Configurations="EditorConfigurations02" Style="margin-top: 20px; border: thin dashed grey; padding: 0 20px 0 20px;" Class="myClassDemo" />

--- a/BlazorEditorJs.Lib/Editor.razor
+++ b/BlazorEditorJs.Lib/Editor.razor
@@ -1,1 +1,1 @@
-﻿<div id="@Id" name="@Name" style="@Style" />
+﻿<div id="@Id" name="@Name" style="@Style" class="@Class" />

--- a/BlazorEditorJs.Lib/Editor.razor.cs
+++ b/BlazorEditorJs.Lib/Editor.razor.cs
@@ -25,6 +25,9 @@ public partial class Editor : ComponentBase
     public string? Style { get; init; }
 
     [Parameter]
+    public string? Class { get; init; }
+
+    [Parameter]
     public required JsonObject Tools { get; init; }
 
     [Parameter]


### PR DESCRIPTION
Fairly simple change here, I've just added a Class parameter on EditorJs.Editor and applied that to the component as the html class. I've also added a demonstration in the second demo on Home.razor.